### PR TITLE
📝 Add METADATA.yaml for working group visibility on amp.dev

### DIFF
--- a/METADATA.yaml
+++ b/METADATA.yaml
@@ -1,0 +1,5 @@
+title: Viewers
+description: Responsible for ensuring support for AMP viewers and for the amp-viewer project
+facilitator:
+  login: ericfs
+  name: Eric Steinlauf


### PR DESCRIPTION
This is part of the effort of making the AMP Project working groups more visible. By adding a METADATA.yaml file to this repository relevant information about the working group (facilitator, team members, channels, etc.) is easily importable by amp.dev's build process and makes it possible to build an AMP page for each working group.

See ampproject/amp.dev#1699 and ampproject/amp.dev#3065 for more history.

/cc @pbakaus, @sebastianbenz